### PR TITLE
Using pyHamcrest for testing (Python 2.6 support)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@
 language: python
 
 python:
+ - "2.6"
  - "2.7"
  - "3.3"
 

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@
 from setuptools import setup
 import os
 import re
+import sys
 
 # Get the version string.  Cannot be done with import!
 with open(os.path.join('invenio_kwalitee', 'version.py'), 'rt') as f:
@@ -31,6 +32,17 @@ with open(os.path.join('invenio_kwalitee', 'version.py'), 'rt') as f:
         '__version__\s*=\s*"(?P<version>.*)"\n',
         f.read()
     ).group('version')
+
+install_requires = [
+    'Flask',
+    'pep8',
+    'pyflakes',
+    'requests',
+    'rq',
+    'six'
+]
+if sys.version_info[0] == 2 and sys.version_info[1] < 7:
+    install_requires.append('importlib')
 
 setup(
     name='Invenio-Kwalitee',
@@ -46,20 +58,18 @@ setup(
     zip_safe=False,
     include_package_data=True,
     platforms='any',
-    install_requires=[
-        'Flask',
-        'pep8',
-        'pyflakes',
-        'requests',
-        'rq',
-        'six'
-    ],
+    install_requires=install_requires,
     classifiers=[
         'Environment :: Web Environment',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: GNU General Public License v2 (GPLv2)',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.6',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.3',
         'Topic :: Internet :: WWW/HTTP :: Dynamic Content',
         'Topic :: Software Development :: Libraries :: Python Modules'
     ],
@@ -69,5 +79,5 @@ setup(
         ],
     },
     test_suite='nose.collector',
-    tests_require=['nose', 'coverage', 'httpretty'],
+    tests_require=['nose', 'coverage', 'httpretty', 'pyhamcrest'],
 )

--- a/tests/test_check_file.py
+++ b/tests/test_check_file.py
@@ -24,6 +24,7 @@
 import os
 from invenio_kwalitee.kwalitee import check_file
 from unittest import TestCase
+from hamcrest import assert_that, equal_to, has_length
 
 
 class TestCheckFile(TestCase):
@@ -38,29 +39,29 @@ class TestCheckFile(TestCase):
     def test_valid_file(self):
         """valid.py has is correct"""
         errors = check_file(self.valid)
-        self.assertEquals(0, len(errors), errors)
+        assert_that(errors, has_length(0), errors)
 
     def test_invalid_file(self):
         """invalid.py has 7 PEP8 violations + 1 from pyFlakes"""
         errors = check_file(self.invalid)
-        self.assertEquals(8, len(errors), errors)
+        assert_that(errors, has_length(8), errors)
 
     def test_erroneous_file(self):
         """error.py has 2 pyflakes violations + 16 pep8"""
         errors = check_file(self.error)
-        self.assertEquals(18, len(errors), errors)
+        assert_that(errors, has_length(18), errors)
 
     def test_pep8_ignore(self):
         """ignored PEP8 codes are ignored"""
         errors = check_file(self.invalid, pep8_ignore=('E111', 'E113', 'E901'))
-        self.assertEquals(0, len(errors), errors)
+        assert_that(errors, has_length(0), errors)
 
     def test_pep8_ignore_license(self):
         """ignored PEP8 codes are ignored"""
         errors = check_file(self.error, pep8_ignore=('E265',))
-        self.assertEquals(2, len(errors), errors)
+        assert_that(errors, has_length(2), errors)
 
     def test_pep8_select(self):
         """selected PEP8 codes are selected"""
         errors = check_file(self.invalid, pep8_select=('E111',))
-        self.assertEquals(3, len(errors), errors)
+        assert_that(errors, has_length(3), errors)

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -22,14 +22,19 @@
 ## or submit itself to any jurisdiction.
 
 import os
+import shutil
+import tempfile
 from unittest import TestCase
 from invenio_kwalitee import app
+from hamcrest import assert_that, equal_to, is_in
 
 
 class IndexTest(TestCase):
     """Integration tests for the homepage"""
     def test_simple_status(self):
         """GET / displays some recent statuses"""
+        instance_path = tempfile.mkdtemp()
+        app.instance_path = instance_path
         filenames = []
         for sha in range(10):
             filename = os.path.join(app.instance_path,
@@ -42,9 +47,8 @@ class IndexTest(TestCase):
         tester = app.test_client(self)
         response = tester.get("/")
 
-        self.assertEquals(200, response.status_code)
+        assert_that(response.status_code, equal_to(200))
         for sha in range(10):
-            self.assertIn("/status/{0}".format(sha), str(response.data))
+            assert_that("/status/{0}".format(sha), is_in(str(response.data)))
 
-        for filename in filenames:
-            os.unlink(filename)
+        shutil.rmtree(instance_path)

--- a/tests/test_ping.py
+++ b/tests/test_ping.py
@@ -24,6 +24,7 @@
 from flask import json
 from unittest import TestCase
 from invenio_kwalitee import app
+from hamcrest import assert_that, equal_to
 
 
 class PingTest(TestCase):
@@ -37,7 +38,7 @@ class PingTest(TestCase):
                                data=json.dumps({"hook_id": 1,
                                                 "zen": "Responsive is better "
                                                        "than fast."}))
-        self.assertEqual(200, response.status_code)
+        assert_that(response.status_code, equal_to(200))
 
     def test_ping_no_headers(self):
         """POST /payload (ping) expects a X-GitHub-Event header"""
@@ -47,10 +48,10 @@ class PingTest(TestCase):
                                                 "zen": "Responsive is better "
                                                        "than fast."}))
         body = json.loads(response.data)
-        self.assertEqual(500, response.status_code)
-        self.assertEqual(u"No X-GitHub-Event HTTP header found",
-                         body["exception"])
-        self.assertEqual(u"failure", body["status"])
+        assert_that(response.status_code, equal_to(500))
+        assert_that(body["exception"],
+                    equal_to("No X-GitHub-Event HTTP header found"))
+        assert_that(body["status"], equal_to(u"failure"))
 
     def test_not_a_ping(self):
         """POST /payload (pong) rejects an unknown event"""
@@ -62,7 +63,7 @@ class PingTest(TestCase):
                                                 "zen": "Responsive is better "
                                                        "than fast."}))
         body = json.loads(response.data)
-        self.assertEqual(500, response.status_code)
-        self.assertEqual(u"Event pong is not supported",
-                         body["exception"])
-        self.assertEqual(u"failure", body["status"])
+        assert_that(response.status_code, equal_to(500))
+        assert_that(body["exception"],
+                    equal_to("Event pong is not supported"))
+        assert_that(body["status"], equal_to(u"failure"))


### PR DESCRIPTION
- Rewrote the `unittest` assertions using `hamcrest`'s
- Enabling Travis testing for 2.6, 2.7, 3.3
- `importlib` is required by `rq` on Python 2.6
- Adding the corresponding classifiers in setup.py
