### PR TITLE
Fix work-in-progress check

### DIFF
--- a/invenio_kwalitee/kwalitee.py
+++ b/invenio_kwalitee/kwalitee.py
@@ -344,7 +344,7 @@ def pull_request(pull_request_url, status_url, config):
 
     # Check only if the title does not contain 'wip'.
     is_wip = bool(re.match(r"\bwip\b", data["title"], re.IGNORECASE))
-    check = not config.get("CHECK_WIP", False) or is_wip
+    check = config.get("CHECK_WIP", False) or not is_wip
     check_commit_messages = config.get("CHECK_COMMIT_MESSAGES", True)
     check_pep8 = config.get("CHECK_PEP8", True)
     check_pyflakes = config.get("CHECK_PYFLAKES", True)


### PR DESCRIPTION
Sorry, I've bodged it when adding the configuration. Currently, if the `CHECK_WIP` flag is set to `False` the checks are gonna be run even if it's a _work-in-progress_ PR. If the `CHECK_WIP` flag is set to `True` the checks are always done, otherwise it must verifies that it's indeed a _work-in-progress_ one.
### Before

| CHECK_WIP | is_wip | check |
| --- | --- | --- |
| True | True | True |
| True | False | **False** |
| False | True | **True** |
| False | False | True |
### After

| CHECK_WIP | is_wip | check |
| --- | --- | --- |
| True | True | True |
| True | False | **True** |
| False | True | **False** |
| False | False | True |
