### PR TITLE
Labels

### DIFF
--- a/invenio_kwalitee/config.py
+++ b/invenio_kwalitee/config.py
@@ -77,3 +77,13 @@ CHECK_PEP8 = True
 # PyFlakes requires PEP8
 CHECK_PYFLAKES = True
 CHECK_LICENSE = True
+
+# Labels applied to the pull request in case we are in the following states:
+# - wip, the wip label has been found in the title
+# - review, some commit need more reviewers
+# - ready, none of the above
+#
+# Default values, uncomment to change:
+#LABEL_WIP = "in_work"
+#LABEL_REVIEW = "in_review"
+#LABEL_READY = "in_integration"

--- a/tests/test_check_message.py
+++ b/tests/test_check_message.py
@@ -37,18 +37,21 @@ class TestCheckMessage(TestCase):
         errors = check_message("", **self.kwargs)
         assert_that(errors,
                     has_items("M101: 1: missing component name",
-                              "M108: 1: signature is missing"))
+                              "M108: 1: signature is missing",
+                              "M100: 1: needs more reviewers"))
 
     def test_no_component_name(self):
         errors = check_message("foo bar", **self.kwargs)
         assert_that(errors,
                     has_items("M101: 1: missing component name",
-                              "M108: 1: signature is missing"))
+                              "M108: 1: signature is missing",
+                              "M100: 1: needs more reviewers"))
 
     def test_known_component_name(self):
         errors = check_message("utils: foo bar", **self.kwargs)
         assert_that(errors,
-                    has_item("M108: 1: signature is missing"))
+                    has_items("M108: 1: signature is missing",
+                              "M100: 1: needs more reviewers"))
 
     def test_unknonwn_component_name(self):
         errors = check_message("kikoo: lol", **self.kwargs)


### PR DESCRIPTION
Here is the new behavior regarding the _Need more reviewers_ error message.
- `in_work` if "WIP" is in the title
- `in_review` if a "needs more reviewers" error is found
- `in_integration` if no "needs more reviewers" errors are found

**NB** It won't create those labels for you.

Other changes:
- messages errors are using the same format than PEP8 error messages with codes and consistent line numbering.
- _signature is missing_ triggers _needs more reviewers_ as well.
