### PR TITLE
test: post_commit_hook

### DIFF
--- a/invenio_kwalitee/hooks.py
+++ b/invenio_kwalitee/hooks.py
@@ -133,6 +133,7 @@ def _check_message(message, options):
             print(error, file=sys.stderr)
 
         return False
+    return True
 
 
 def prepare_commit_msg_hook(argv):
@@ -159,7 +160,7 @@ def commit_msg_hook(argv):
         return False
 
 
-def post_commit_hook(argv):
+def post_commit_hook(argv=None):
     """Hook: for checking commit message"""
     _, stdout, _ = run("git log -1 --format=%B HEAD")
     message = "\n".join(stdout)
@@ -270,8 +271,8 @@ def run(command, raw_output=False):
     if not raw_output:
         return (
             p.returncode,
-            [line.strip() for line in stdout.decode("utf-8").splitlines()],
-            [line.strip() for line in stderr.decode("utf-8").splitlines()]
+            [line.rstrip() for line in stdout.decode("utf-8").splitlines()],
+            [line.rstrip() for line in stderr.decode("utf-8").splitlines()]
         )
     else:
         return (p.returncode, stdout, stderr)

--- a/invenio_kwalitee/kwalitee.py
+++ b/invenio_kwalitee/kwalitee.py
@@ -180,9 +180,9 @@ def check_message(message, **kwargs):
     errors += _check_signatures(signature_lines, **kwargs)
 
     def _format(code, lineno, args):
-        return "{0}: {1}: {2}".format(code,
-                                      lineno,
-                                      _messages_codes[code].format(*args))
+        return u"{0}: {1}: {2}".format(code,
+                                       lineno,
+                                       _messages_codes[code].format(*args))
 
     return list(map(lambda x: _format(x[0], x[1], x[2:]), errors))
 


### PR DESCRIPTION
- fixing the check message problem with multiline bullet introduced by
  stripping the lines from the git call output.
- code coverage up by 2%
