### PR TITLE
python 3.4 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,11 +27,14 @@ python:
  - "2.6"
  - "2.7"
  - "3.3"
+ - "3.4"
 
 install:
   - pip install --upgrade pip  --use-mirrors
+  - travis_retry pip install -r requirements.txt
+  - travis_retry pip install -r requirements-test.txt
+  - pip install -e .
   - pip install coveralls --use-mirrors
-  - pip install .
 
 script:
   - coverage run --source=invenio_kwalitee setup.py test

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,0 +1,5 @@
+coverage
+httpretty
+mock
+nose
+pyhamcrest

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+Flask
+Flask-Script
+pep8
+pep257
+pyflakes
+requests
+rq

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,19 @@ import os
 import re
 import sys
 
+
+def reqs(filename):
+    """Read the requirements from a file."""
+    return [r.strip() for r in open(filename, 'r').readlines()]
+
+
+install_requires = reqs('requirements.txt')
+test_requires = reqs('requirements-test.txt')
+
+if tuple(sys.version_info) < (2, 7):
+    install_requires.append('importlib')
+
+
 # Get the version string.  Cannot be done with import!
 with open(os.path.join('invenio_kwalitee', 'version.py'), 'rt') as f:
     version = re.search(
@@ -35,25 +48,6 @@ with open(os.path.join('invenio_kwalitee', 'version.py'), 'rt') as f:
         f.read()
     ).group('version')
 
-install_requires = [
-    'Flask',
-    'Flask-Script',
-    'pep8',
-    'pep257',
-    'pyflakes',
-    'requests',
-    'rq'
-]
-test_requires = [
-    'coverage',
-    'httpretty',
-    'mock',
-    'nose',
-    'pyhamcrest'
-]
-
-if tuple(sys.version_info) < (2, 7):
-    install_requires.append('importlib')
 
 setup(
     name='Invenio-Kwalitee',
@@ -81,6 +75,7 @@ setup(
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.3',
+        'Programming Language :: Python :: 3.4',
         'Topic :: Internet :: WWW/HTTP :: Dynamic Content',
         'Topic :: Software Development :: Libraries :: Python Modules'
     ],

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,6 @@
 [tox]
-envlist = py26, py27, py33
+envlist = py26, py27, py33, py34
 
 [testenv]
-commands =
-    {envpython} setup.py test
-deps =
-    nose
-    sphinx
+commands = {envpython} setup.py nosetests
+deps = nose


### PR DESCRIPTION
- Moving the requirements to text files.
- Using `travis_retry` to bypass Python 3.4 issues.
