### PR TITLE
hooks: exit code fix

### DIFF
--- a/invenio_kwalitee/hooks.py
+++ b/invenio_kwalitee/hooks.py
@@ -36,7 +36,6 @@ from subprocess import Popen, PIPE
 from .kwalitee import check_file, check_message, get_options, SUPPORTED_FILES
 
 
-
 def _get_files_modified():
     """Get the list of modified files that are Python or Jinja2."""
     cmd = "git diff-index --cached --name-only --diff-filter=ACMRTUXB HEAD"
@@ -144,6 +143,7 @@ def prepare_commit_msg_hook(argv):
                         _get_git_author(),
                         _get_files_modified(),
                         template)
+    return 0
 
 
 def commit_msg_hook(argv):
@@ -156,7 +156,8 @@ def commit_msg_hook(argv):
     if not _check_message(message, options):
         print("Aborting commit due to commit message errors (override with "
               "'git commit --no-verify').", file=sys.stderr)
-        return False
+        return 1
+    return 0
 
 
 def post_commit_hook(argv=None):
@@ -168,8 +169,8 @@ def post_commit_hook(argv=None):
     if not _check_message(message, options):
         print("Commit message errors (fix with 'git commit --amend').",
               file=sys.stderr)
-
-        return False
+        return 1
+    return 0
 
 
 # =============================================================================
@@ -255,7 +256,8 @@ def pre_commit_hook(argv=None):
         print("Aborting commit due to kwalitee errors (override with "
               "'git commit --no-verify').",
               file=sys.stderr)
-        return False
+        return 1
+    return 0
 
 
 def run(command, raw_output=False):

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -236,7 +236,7 @@ def test_post_commit_hook(github):
     stderr = sys.stderr
 
     sys.stderr = StringIO()
-    assert_that(not post_commit_hook())
+    assert_that(post_commit_hook() == 0)
     sys.stderr.seek(0)
     output = "\n".join(sys.stderr.readlines())
     sys.stderr = stderr
@@ -249,7 +249,7 @@ def test_pre_commit_hook(github):
     stderr = sys.stderr
 
     sys.stderr = StringIO()
-    assert_that(not pre_commit_hook())
+    assert_that(pre_commit_hook() == 1)
     sys.stderr.seek(0)
     output = "\n".join(sys.stderr.readlines())
     sys.stderr = stderr


### PR DESCRIPTION
Fixes problem with hooks exit code, that prevented hooks from aborting the commit.

Hook functions would return `False` on failures, and `None` on success which would be passed to `sys.exit()`. Both however result in exit code 0:

``` console
$ python -c "import sys;sys.exit(None)" ; echo $?
0
$ python -c "import sys;sys.exit(False)" ; echo $?
0
```

Thus hook functions now return an integer (0 or 1).
