### PR TITLE
pygit2 and colors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,8 +29,24 @@ python:
  - "3.3"
  - "3.4"
 
+env:
+  global:
+    - LD_LIBRARY_PATH="/usr/local/lib:$LD_LIBRARY_PATH"
+  matrix:
+    - WITH_PYGIT2=true
+    - WITH_PYGIT2=false
+
 install:
-  - pip install --upgrade pip  --use-mirrors
+  - sudo apt-get install -qy python-dev libffi-dev cmake
+  - pip install --upgrade pip --use-mirrors
+  # libgit2-dev isn't available from ubuntu, and ppa:dennis doesn't work with
+  # the Ubuntu LTS version travis is using.
+  - $WITH_PYGIT2 && wget https://github.com/libgit2/libgit2/archive/v0.21.0.tar.gz || true
+  - $WITH_PYGIT2 && tar xzf v0.21.0.tar.gz || true
+  - $WITH_PYGIT2 && cd libgit2-0.21.0/ || true
+  - $WITH_PYGIT2 && cmake . && make && sudo make install || true
+  - $WITH_PYGIT2 && cd .. || true
+  - $WITH_PYGIT2 && pip install cffi pygit2 --use-mirrors || true
   - travis_retry pip install -r requirements.txt
   - travis_retry pip install -r requirements-docs.txt
   - travis_retry pip install coveralls pytest --use-mirrors

--- a/invenio_kwalitee/cli/__init__.py
+++ b/invenio_kwalitee/cli/__init__.py
@@ -24,8 +24,6 @@
 """Command line interfaces entrypoints."""
 
 
-import sys
-
 from flask.ext.script import Manager
 
 from . import account, check, githooks, repository
@@ -36,9 +34,7 @@ manager = Manager()
 manager.add_command("account", account.manager)
 manager.add_command("githooks", githooks.manager)
 manager.add_command("repository", repository.manager)
-
-if tuple(sys.version_info) < (3, 0):
-    manager.add_command("check", check.manager)
+manager.add_command("check", check.manager)
 
 
 def main():  # pragma: no cover

--- a/invenio_kwalitee/cli/check.py
+++ b/invenio_kwalitee/cli/check.py
@@ -89,12 +89,10 @@ def message(commit='HEAD', repository='.'):
         reset = yellow = green = red = ''
 
     try:
-        import pygit2  # noqa
         sha = "oid"
         commits = _pygit2_commits(commit, repository)
     except ImportError:
         try:
-            import git  # noqa
             sha = "hexsha"
             commits = _git_commits(commit, repository)
         except ImportError:

--- a/invenio_kwalitee/kwalitee.py
+++ b/invenio_kwalitee/kwalitee.py
@@ -544,7 +544,8 @@ def get_options(config):
         "select": config.get("SELECT"),
         "match": config.get("PEP257_MATCH"),
         "match_dir": config.get("PEP257_MATCH_DIR"),
-        "min_reviewers": config.get("MIN_REVIEWERS")
+        "min_reviewers": config.get("MIN_REVIEWERS"),
+        "colors": config.get("COLORS", True),
     }
     options = {}
     for k, v in base.items():

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,11 @@ if tuple(sys.version_info) < (2, 7):
     install_requires.append('argparse')
     install_requires.append('importlib')
 if tuple(sys.version_info) < (3, 0):
-    install_requires.append('GitPython>=0.3.2.RC1')
+    # If pygit2 is not installed, grab GitPython instead.
+    try:
+        import pygit2
+    except ImportError:
+        install_requires.append('GitPython>=0.3.2.RC1')
 
 test_requires = [
     'pytest-cov',

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ from setuptools.command.test import test as TestCommand
 
 install_requires = [
     'alembic',
+    'colorama',
     'Flask',
     'Flask-Script',
     'Flask-SQLAlchemy',

--- a/tests/cli/test_check.py
+++ b/tests/cli/test_check.py
@@ -29,11 +29,17 @@ from hamcrest import assert_that, equal_to, has_item, has_items
 
 from invenio_kwalitee.cli.check import message
 
+try:
+    import pygit2
+    pygit = True
+except ImportError:
+    pygit = False
 
-py3k = pytest.mark.skipif(sys.version_info > (3, 0), reason="not py3k ready")
+skip = pytest.mark.skipif(sys.version_info > (3, 0) and not pygit,
+                          reason="no pygit2 and not GitPython")
 
 
-@py3k
+@skip
 def test_check_head(capsys, session, git):
     assert_that(message("HEAD", repository=git), equal_to(1))
 
@@ -44,7 +50,7 @@ def test_check_head(capsys, session, git):
                           "1: M100 needs more reviewers"))
 
 
-@py3k
+@skip
 def test_check_branch(capsys, session, app, git):
     app.config['TRUSTED_DEVELOPERS'] = ('a@b.org',)
     app.config['SIGNATURES'] = ('By',)
@@ -56,7 +62,7 @@ def test_check_branch(capsys, session, app, git):
     assert_that(out.split("\n"), has_item("Everything is OK."))
 
 
-@py3k
+@skip
 def test_check_branch_wrong_side(capsys, session, git):
     assert_that(message("testbranch..master", repository=git), equal_to(0))
 

--- a/tests/cli/test_check.py
+++ b/tests/cli/test_check.py
@@ -30,7 +30,7 @@ from hamcrest import assert_that, equal_to, has_item, has_items
 from invenio_kwalitee.cli.check import message
 
 try:
-    import pygit2
+    import pygit2  # noqa
     pygit = True
 except ImportError:
     pygit = False
@@ -40,7 +40,9 @@ skip = pytest.mark.skipif(sys.version_info > (3, 0) and not pygit,
 
 
 @skip
-def test_check_head(capsys, session, git):
+def test_check_head(capsys, session, app, git):
+    app.config['COLORS'] = False
+
     assert_that(message("HEAD", repository=git), equal_to(1))
 
     out, _ = capsys.readouterr()
@@ -55,6 +57,7 @@ def test_check_branch(capsys, session, app, git):
     app.config['TRUSTED_DEVELOPERS'] = ('a@b.org',)
     app.config['SIGNATURES'] = ('By',)
     app.config['COMPONENTS'] = ('global',)
+    app.config['COLORS'] = False
 
     assert_that(message("master..testbranch", repository=git), equal_to(0))
 
@@ -63,7 +66,9 @@ def test_check_branch(capsys, session, app, git):
 
 
 @skip
-def test_check_branch_wrong_side(capsys, session, git):
+def test_check_branch_wrong_side(capsys, session, app, git):
+    app.config['COLORS'] = False
+
     assert_that(message("testbranch..master", repository=git), equal_to(0))
 
     out, _ = capsys.readouterr()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -114,6 +114,7 @@ def repository(owner, session, request):
     request.addfinalizer(teardown)
     return repo
 
+
 @pytest.fixture(scope="function")
 def git(request):
     """Create a git repository."""


### PR DESCRIPTION
- Uses pygit2 if it's installed otherwise it falls back to git-python.
- Colored output for the rainbow and unicorn lovers via colorama.

![colorama](https://cloud.githubusercontent.com/assets/1388/3717716/8558ab82-162a-11e4-8d28-846c5fb5b201.png)
