### PR TITLE
scripts: initial release of prepare-release-news

### DIFF
--- a/.kwalitee.yml
+++ b/.kwalitee.yml
@@ -7,6 +7,7 @@ components:
 - hooks
 - installation
 - kwalitee
+- scripts
 - tests
 - travis
 - views

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,8 @@
 # granted to it by virtue of its status as an Intergovernmental Organization
 # or submit itself to any jurisdiction.
 
+sudo: true
+
 language: python
 
 python:
@@ -38,7 +40,7 @@ env:
 
 install:
   - sudo apt-get install -qy python-dev libffi-dev cmake
-  - pip install --upgrade pip --use-mirrors
+  - pip install --upgrade pip
   # libgit2-dev isn't available from ubuntu, and ppa:dennis doesn't work with
   # the Ubuntu LTS version travis is using.
   - $WITH_PYGIT2 && wget https://github.com/libgit2/libgit2/archive/v0.21.0.tar.gz || true
@@ -46,10 +48,10 @@ install:
   - $WITH_PYGIT2 && cd libgit2-0.21.0/ || true
   - $WITH_PYGIT2 && cmake . && make && sudo make install || true
   - $WITH_PYGIT2 && cd .. || true
-  - $WITH_PYGIT2 && pip install cffi pygit2 --use-mirrors || true
+  - $WITH_PYGIT2 && pip install cffi pygit2 || true
   - travis_retry pip install -r requirements.txt
   - travis_retry pip install -r requirements-docs.txt
-  - travis_retry pip install coveralls pytest --use-mirrors
+  - travis_retry pip install coveralls pytest
 
 script:
   - python setup.py test -a "tests --cov-config .coveragerc --cov kwalitee --cov-report term-missing"

--- a/scripts/prepare-release-news
+++ b/scripts/prepare-release-news
@@ -1,0 +1,225 @@
+#!/usr/bin/env python
+
+"""prepare-release-news -- prepare release news from git log.
+
+Description:
+
+  Prepares release news from git log messages, breaking release news
+  into (1) sections (e.g. Security fixes, detected from commit labels)
+  and (2) modules (e.g. search, detected from commit log headlines).
+
+Usage:
+
+  $ prepare-release-news [options] sha1a[..sha1b]
+
+      -h, --help    print this help
+      -t, --test    run test suite
+      -v            increase verbosity
+
+Examples:
+
+  $ prepare-release-news -v --test  # run test suite
+  $ prepare-release-news v1.0.3..maint-1.0  # prepare release of v1.0.4
+
+"""
+
+import re
+import subprocess
+import sys
+import textwrap
+
+CFG_LABELS = (('SECURITY', 'Security fixes'),
+              ('INCOMPATIBLE', 'Incompatible changes'),
+              ('NEW', 'New features'),
+              ('BETTER', 'Improved features'),
+              ('FIX', 'Bug fixes'),
+              ('NOTE', 'Notes'),
+              ('AMENDS', 'AMENDS'),
+              ('NOBODY', 'PLEASE CHECK THE FOLLOWING COMMITS WITHOUT BODY!'),
+              ('NOLABEL', 'PLEASE CHECK THE FOLLOWING UNLABELLED NEWS ITEMS!'))
+
+
+def get_label_text(label):
+    """Return full text of the label.
+
+    >>> get_label_text('NEW')
+    'New features'
+    >>> get_label_text('NOTE')
+    'Notes'
+    """
+    for label_value, label_text in CFG_LABELS:
+        if label_value == label:
+            return label_text
+    raise KeyError
+
+
+def analyse_body_paragraph(body_paragraph):
+    """Analyse commit body paragraph and return (label, message).
+
+    >>> analyse_body_paragraph('* BETTER Foo and bar.')
+    ('BETTER', 'Foo and bar.')
+    >>> analyse_body_paragraph('* Foo and bar.')
+    ('NOLABEL', 'Foo and bar.')
+    >>> analyse_body_paragraph('Foo and bar.')
+    ('NOLABEL', None)
+    """
+    # try to find leading label first:
+    for label, dummy in CFG_LABELS:
+        if body_paragraph.startswith('* ' + label):
+            return (label, body_paragraph[len(label) + 3:].replace('\n  ',
+                                                                   ' '))
+    # no conformed leading label found; do we have leading asterisk?
+    if body_paragraph.startswith('* '):
+        return ('NOLABEL', body_paragraph[2:].replace('\n  ', ' '))
+    # no leading asterisk found; ignore this paragraph silently:
+    return ('NOLABEL', None)
+
+
+def remove_ticket_directives(message):
+    """Remove ticket directives like "(closes #123).
+
+    >>> remove_ticket_directives('(closes #123)')
+    '(#123)'
+    >>> remove_ticket_directives('(foo #123)')
+    '(foo #123)'
+    """
+    if message:
+        message = re.sub(r'closes #', '#', message)
+        message = re.sub(r'addresses #', '#', message)
+        message = re.sub(r'references #', '#', message)
+    return message
+
+
+def git_branch_commits(sha1range):
+    """
+    Return list of dicts representing git commit logs for SHA1RANGE.
+
+    See also http://blog.lost-theory.org/post/how-to-parse-git-log-output/
+    """
+    process = subprocess.Popen([
+        'git', 'log', sha1range,
+        '--format=%H%x1f%an%x1f%ae%x1f%ad%x1f%s%x1f%b%x1e'],
+                               stdout=subprocess.PIPE,
+                               stderr=subprocess.PIPE)
+    process_output, process_error = process.communicate()
+    if process_error:
+        print "[ERROR]", process_error
+        sys.exit(1)
+    logds = process_output.strip('\n\x1e').split('\x1e')
+    logds = [row.strip().split('\x1f') for row in logds]
+    logds = [dict(zip(['id', 'author_name', 'author_email', 'date',
+                      'message', 'body'], row)) for row in logds]
+    return logds
+
+
+def remove_amended_commits(logds):
+    """Remove those git commit logs that have been amended later."""
+    logds_filtered = []
+    # which SHA1 are declared as amended later?
+    amended_sha1s = []
+    for l in logds:
+        amended_sha1s.extend(re.findall(r'AMENDS\s([0-f]+)',
+                                        l.get('body', '')))
+    # remove them
+    for logd in logds:
+        if logd.get('id') not in amended_sha1s:
+            logds_filtered.append(logd)
+    return logds_filtered
+
+
+def enrich_git_log_dict(logds):
+    """Enrich git log with Invenio related information on tickets."""
+    for l in logds:
+        message = l.get('message', '')
+        # detect Invenio module and ticket numbers for each commit:
+        try:
+            invenio_module, invenio_message = message.split(":", 1)
+        except ValueError:
+            invenio_module = 'FIXME'  # noqa
+            invenio_message = l.get('message', repr(l))
+        # recognise tickets:
+        l['invenio_module'] = invenio_module.strip()
+        l['invenio_message'] = invenio_message.strip()
+        l['invenio_ticket'] = re.findall(r'\s(#\d+)', l['body'])
+        # recognise body paragraphs:
+        body_paragraphs = l['body'].split('\n\n')
+        if len(body_paragraphs) == 1 and not l['body'].startswith('* '):
+            # commit with no body:
+            label = 'NOBODY'
+            message = l['invenio_message']
+            if 'invenio_label_' + label in l:
+                l['invenio_label_' + label].append(message)
+            else:
+                l['invenio_label_' + label] = [message, ]
+        else:
+            # commit with one or more body paragraphs:
+            for body_paragraph in body_paragraphs:
+                label, message = analyse_body_paragraph(body_paragraph)
+                message = remove_ticket_directives(message)
+                if message:
+                    if 'invenio_label_' + label in l:
+                        l['invenio_label_' + label].append(message)
+                    else:
+                        l['invenio_label_' + label] = [message, ]
+
+
+def summarise_git_log_dict(logds, label):
+    """Create textual summary on recognised commits."""
+    label_header_printed_p = False
+    modules = {l['invenio_module']: 1 for l in logds}
+    modules = modules.keys()
+    modules.sort()
+    for m in modules:
+        module_header_printed_p = False
+        for l in logds:
+            if l['invenio_module'] == m:
+                    if 'invenio_label_' + label in l:
+                        for msg in l['invenio_label_' + label]:
+                            if not module_header_printed_p:
+                                if not label_header_printed_p:
+                                    print get_label_text(label)
+                                    print '-' * len(get_label_text(label))
+                                    print
+                                    label_header_printed_p = True
+                                print "+ " + m + ":"
+                                print
+                                module_header_printed_p = True
+                            wrapper = textwrap.TextWrapper(
+                                width=70, initial_indent='  - ',
+                                subsequent_indent='    ')
+                            print wrapper.fill(msg)
+                            print
+
+
+def usage():
+    """Print usage."""
+    print __doc__
+
+
+def test():
+    """Run all doctests."""
+    import doctest
+    doctest.testmod()
+
+
+def main():
+    """Main entry."""
+    try:
+        sha1range = sys.argv[1]
+    except IndexError:
+        usage()
+        sys.exit(1)
+    logds = git_branch_commits(sha1range)
+    logds = remove_amended_commits(logds)
+    enrich_git_log_dict(logds)
+    for label, dummy in CFG_LABELS:
+        summarise_git_log_dict(logds, label)
+
+
+if __name__ == '__main__':
+    if '-h' in sys.argv or '--help' in sys.argv:
+        usage()
+    elif '-t' in sys.argv or '--test' in sys.argv:
+        test()
+    else:
+        main()


### PR DESCRIPTION
- NEW Initial release of `prepare-release-news` helper script that aids
  in compiling release notes from git commit log messages.  (closes #71)
- Imports "as is" a previous standalone personal script that can be
  amended later to profit from the kwalitee package ecosystem, e.g. the
  configuration parts can be moved to `.kwalitee.yml`, etc.

Signed-off-by: Tibor Simko tibor.simko@cern.ch
