### PR TITLE
cli: author checking encoding fix

### DIFF
--- a/.kwalitee.yml
+++ b/.kwalitee.yml
@@ -10,3 +10,7 @@ components:
 - tests
 - travis
 - views
+exclude_author_names:
+- Jiri Kuncar <jiri.kuncar@gmail.com>
+- Mateusz Susik <mateusz.susik@cern.ch>
+- Yoan Blanc <yoan.blanc@cern.ch>

--- a/kwalitee/cli/check.py
+++ b/kwalitee/cli/check.py
@@ -323,7 +323,7 @@ def authors(obj, commit='HEAD', skip_merge_commits=False):
         if skip_merge_commits and _is_merge_commit(commit):
             continue
         message = commit.message
-        author = str(commit.author) + ' <' + commit.author.email + '>'
+        author = u'{0.author} <{0.author.email}>'.format(commit).encode('utf-8')
         errors = check_author(author, **options)
         message = re.sub(re_line, ident, message)
         if errors:
@@ -334,7 +334,7 @@ def authors(obj, commit='HEAD', skip_merge_commits=False):
         errors.append(reset)
 
         click.echo(template.format(commit=commit,
-                                   message=message,
+                                   message=message.encode('utf-8'),
                                    errors='\n'.join(errors)))
 
     if min(count, 1):


### PR DESCRIPTION
- FIX Fixes invalid encoding problems in author checking. (closes #87)
- Completes the alternative author names to exclude so that the author
  checking works fully in this very repository.
  (`kwalitee check authors adf1d899..`)

Signed-off-by: Tibor Simko tibor.simko@cern.ch
