### PR TITLE
docs: pydocstyle warning fix

### DIFF
--- a/kwalitee/kwalitee.py
+++ b/kwalitee/kwalitee.py
@@ -366,8 +366,7 @@ def check_pep8(filename, **kwargs):
     :return: errors
     :rtype: `list`
 
-    .. seealso:: :py:class:`pep8.Checker`
-
+    .. seealso:: :py:class:`pycodestyle.Checker`
     """
     options = {
         "ignore": kwargs.get("ignore"),


### PR DESCRIPTION
- Fixes pydocstyle warning, fixing Travis CI build failure.

Signed-off-by: Tibor Simko tibor.simko@cern.ch
