### PR TITLE
global: inveniosoftware.org

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -25,9 +25,9 @@ Authors
 -------
 
 kwalitee is developed to support developers of
-`Invenio <http://invenio-software.org>`_ digital library software.
+`Invenio <http://inveniosoftware.org>`_ digital library software.
 
-Contact us at `info@invenio-software.org <mailto:info@invenio-software.org>`_.
+Contact us at `info@inveniosoftware.org <mailto:info@inveniosoftware.org>`_.
 
 Contributors
 ^^^^^^^^^^^^

--- a/RELEASE-NOTES.rst
+++ b/RELEASE-NOTES.rst
@@ -61,8 +61,8 @@ Homepage
 Happy hacking and thanks for flying kwalitee.
 
 | Invenio Development Team
-|   Email: info@invenio-software.org
+|   Email: info@inveniosoftware.org
 |   IRC: #invenio on irc.freenode.net
 |   Twitter: http://twitter.com/inveniosoftware
 |   GitHub: http://github.com/inveniosoftware
-|   URL: http://invenio-software.org
+|   URL: http://inveniosoftware.org

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,7 +39,7 @@ directory = kwalitee/translations/
 
 [extract_messages]
 copyright_holder = CERN
-msgid_bugs_address = info@invenio-software.org
+msgid_bugs_address = info@inveniosoftware.org
 mapping-file = babel.ini
 output-file = kwalitee/translations/messages.pot
 add-comments = NOTE

--- a/setup.py
+++ b/setup.py
@@ -94,7 +94,7 @@ setup(
     long_description=readme + '\n\n' + history,
     license='GPLv2',
     author='CERN',
-    author_email='info@invenio-software.org',
+    author_email='info@inveniosoftware.org',
     url='https://github.com/inveniosoftware/kwalitee',
     packages=packages,
     zip_safe=False,


### PR DESCRIPTION
- Changes `invenio-software.org` to `inveniosoftware.org` to use the
  same dashless canonical ID everywhere (GitHub, Twitter, Web).

Signed-off-by: Tibor Simko tibor.simko@cern.ch
