### PR TITLE
cli: fix author name in output

### DIFF
--- a/kwalitee/cli/check.py
+++ b/kwalitee/cli/check.py
@@ -323,7 +323,7 @@ def authors(obj, commit='HEAD', skip_merge_commits=False):
         if skip_merge_commits and _is_merge_commit(commit):
             continue
         message = commit.message
-        author = u'{0.author} <{0.author.email}>'.format(
+        author = u'{0.author.name} <{0.author.email}>'.format(
             commit).encode('utf-8')
         errors = check_author(author, **options)
         message = re.sub(re_line, ident, message)


### PR DESCRIPTION
- Fixes 'authors: wrong format in error message'. (closes #100)

Signed-off-by: Ivan Masár helix84@centrum.sk
